### PR TITLE
Transparent proxying of *all* RPC commands.

### DIFF
--- a/src/restapi/restapi.go
+++ b/src/restapi/restapi.go
@@ -152,7 +152,15 @@ func handleJson(action string, respBody []byte, w http.ResponseWriter) {
 		return
 
 	default:
-		fmt.Fprintln(w, `{"error":"unknown action","action":"` + action + "}")
+		// proxy any other request unmodified
+		log.Println("transaprent proxying of action", action)
+		respJSON, err := rpcclient.MakeGenericCall(nanoNodeUrl, string(respBody))
+		if (err != nil) {
+			log.Println("RPC error:", err.Error())
+			fmt.Fprintln(w, `{"error":"RPC error: ` + err.Error() + `","action":"` + action + `"}`)
+			return
+		}
+		fmt.Fprintln(w, respJSON)
 	}
 }
 

--- a/src/rpcclient/rpc-client.go
+++ b/src/rpcclient/rpc-client.go
@@ -114,3 +114,13 @@ func GetFrontier(url string, account string) (string, error) {
 	}
 	return frontier, nil
 }
+
+/// Make a generic call to the RPC node
+func MakeGenericCall(url string, reqJSON string) (string, error) {
+	//fmt.Println(reqJson)
+	respString, err := RpcCall(url, reqJSON)
+	if (err != nil) {
+		return "", err
+	}
+	return respString, nil;
+}


### PR DESCRIPTION
Solves issue #2 .